### PR TITLE
Rename rosters table to players

### DIFF
--- a/db/migrations/20200131101424_rename-players-table.js
+++ b/db/migrations/20200131101424_rename-players-table.js
@@ -1,0 +1,28 @@
+
+exports.up = function(knex) {
+  return knex.schema
+    .dropTable('roster')
+
+    .createTable('players', table => {
+      table.increments('id').primary();
+      table.string('first_name');
+      table.string('last_name');
+      table.integer('team_id').unsigned();
+      table.foreign('team_id')
+        .references('teams.id');
+      table.timestamps(true, true);
+    })
+};
+
+exports.down = function(knex) {
+  return knex.schema
+    .createTable('roster', table => {
+      table.increments('id').primary();
+      table.string('first_name');
+      table.string('last_name');
+      table.integer('team_id').unsigned();
+      table.foreign('team_id')
+        .references('teams.id');
+      table.timestamps(true, true);
+    });
+};

--- a/db/seeds/dev/teams.js
+++ b/db/seeds/dev/teams.js
@@ -20,12 +20,12 @@ const createTeam = async (knex, team) => {
 };
 
 const createRoster = (knex, roster) => {
-  return knex('roster').insert(roster)
+  return knex('players').insert(roster)
 };
 
 exports.seed = async knex => {
   try {
-    await knex('roster').del();
+    await knex('players').del();
     await knex('teams').del();
 
     let teamPromises = teams.map(team => {

--- a/server.js
+++ b/server.js
@@ -58,7 +58,7 @@ app.get('/api/v1/teams/:id/roster', async (req, res) => {
     if (!teamId) {
       return res.status(404).json(`No team found with id ${id}`)
     } else {
-      const roster = await database('roster').where('team_id', Number(teamId)).select();
+      const roster = await database('players').where('team_id', Number(teamId)).select();
       const displayRoster = roster.map(player => {
       return {
         id: player.id,
@@ -75,7 +75,7 @@ app.get('/api/v1/teams/:id/roster', async (req, res) => {
 
 app.get('/api/v1/players', async (req, res) => {
   try {
-    const players = await database('roster').select();
+    const players = await database('players').select();
     const displayPlayers = players.map(player => {
       return {
         id: player.id,
@@ -128,7 +128,7 @@ app.post('/api/v1/teams/:id/roster', async (req, res) => {
 
   try {
     const { first_name, last_name } = player;
-    const id = await database('roster').insert(player, 'id');
+    const id = await database('players').insert(player, 'id');
     res.status(201).json({
       id: id[0],
       first_name,
@@ -142,7 +142,7 @@ app.post('/api/v1/teams/:id/roster', async (req, res) => {
 app.delete('/api/v1/players/:id', async (req, res) => {
   const { id } = req.params;
   try {
-    await database('roster').where('id', id).del();
+    await database('players').where('id', id).del();
     res.sendStatus(204)
   } catch (error) {
     res.status(500).send({ error: 'Internal server error.' })


### PR DESCRIPTION
### What does this PR do?
This PR renames the `roster` table to `players`. 

### Where should the reviewer start?
In the `/db/migrations` you'll see a new migration. In the `/db/seeds/teams.js` and `server.js` files, each reference to `database('roster')` has been changed to `database('players')`